### PR TITLE
feat: 조회조건 영역 컴포넌트 구현 (1차)

### DIFF
--- a/src/components/common/layout/conditions/conditionItem/index.jsx
+++ b/src/components/common/layout/conditions/conditionItem/index.jsx
@@ -1,0 +1,37 @@
+import ConditionPicker from "@/src/components/common/layout/conditions/conditionPicker";
+
+export default function ConditionItem(props) {
+    const {
+        label,
+        id,
+        type,
+        value,
+        onChange,
+        options,
+        placeholder,
+        min,
+        max,
+    } = props;
+
+    if (label === undefined) {
+        throw new Error("orderKeys에 작성한 conditions와 일치하는 label이 지정되지 않았습니다. 다시 가서 작성하고 오세요^^");
+    }
+
+    return (
+        <div className="flex flex-row items-center p-2 gap-2">
+            <label className="weight-600 text-[15px] w-[80px] text-right">{label}</label>
+            <div className="flex gap-2">
+                <ConditionPicker
+                    id={id}
+                    type={type}
+                    value={value}
+                    onChange={onChange}
+                    options={options}
+                    placeholder={placeholder}
+                    min={min}
+                    max={max}
+                />
+            </div>
+        </div>
+    )
+}

--- a/src/components/common/layout/conditions/conditionPanel/index.jsx
+++ b/src/components/common/layout/conditions/conditionPanel/index.jsx
@@ -1,0 +1,43 @@
+import ConditionItem from "@/src/components/common/layout/conditions/conditionItem";
+import {Button} from "antd";
+
+export default function ConditionPanel(props) {
+    const {
+        conditions,
+        onConditionChange,
+        onSearch,
+        orderKeys,
+        types,
+        labels,
+        options,
+        min,
+        max
+    } = props;
+
+    return (
+        <div className="flex flex-row items-end">
+            <div className="flex flex-row flex-wrap">
+                {orderKeys.map((condition) => (
+                    <ConditionItem
+                        key={condition}
+                        label={labels[condition]}
+                        value={conditions[condition]}
+                        id={condition}
+                        onChange={onConditionChange}
+                        options={options?.[condition] || []}
+                        type={types?.[condition] || "text"}
+                        min={min}
+                        max={max}
+                    />
+                ))}
+            </div>
+
+            <div className="p-2">
+                <Button color="primary" variant="outlined"
+                        style={{width: 70}} onClick={onSearch}>
+                    조회
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/common/layout/conditions/conditionPicker/index.jsx
+++ b/src/components/common/layout/conditions/conditionPicker/index.jsx
@@ -1,0 +1,101 @@
+import { Select, DatePicker, Input, InputNumber } from 'antd';
+import en from 'antd/es/date-picker/locale/en_US';
+import enUS from 'antd/es/locale/en_US';
+import dayjs from 'dayjs';
+import buddhistEra from 'dayjs/plugin/buddhistEra';
+dayjs.extend(buddhistEra);
+
+export default function ConditionPicker(props) {
+    const {
+        id,
+        type = "text",
+        value,
+        onChange,
+        options = [],
+        placeholder = "",
+        min = 0,
+        max = 5000000,
+    } = props;
+
+    const { RangePicker } = DatePicker;
+
+    if (type === "text") {
+        return (
+            <Input
+                value={value}
+                onChange={onChange}
+                placeholder={placeholder}
+                style={{width: 130, fontSize: "14px"}}
+            />
+        );
+    }
+
+    if (type === "number") {
+        return (
+            <InputNumber
+                type="number"
+                defaultValue={value}
+                onChange={onChange}
+                min={min}
+                max={max}
+                style={{width: 130, fontSize: "14px"}}
+            />
+        );
+    }
+
+    if (type === "selectWithSearch") {
+        return (
+            <Select
+                id={id}
+                defaultValue={value}
+                onChange={onChange}
+                showSearch
+                style={{width: 130, fontSize: "14px"}}
+                options={options.map((option) => ({ label: option, value: option }))}
+            />
+        );
+    }
+
+    if (type === "select") {
+        return (
+            <Select
+                id={id}
+                defaultValue={value}
+                onChange={onChange}
+                style={{width: 130, fontSize: "14px"}}
+                options={options.map((option) => ({ label: option, value: option }))}
+            />
+        );
+    }
+
+    if (type === "date") {
+        return (
+            <DatePicker
+                popupStyle={{fontSize: "14px"}}
+                defaultValue={value}
+                onChange={(date, dateString) => onChange({ target: { value: dateString } })}
+            />
+        );
+    }
+
+    if (type === "rangeDate") {
+        const {from, to} = value;
+
+        return (
+            <RangePicker
+                popupStyle={{fontSize: "14px"}}
+                defaultValue={[dayjs(from, 'YYYY-MM-DD'), dayjs(to, 'YYYY-MM-DD')]}
+                onChange={(_, dateString) => onChange({ target: { value: { from: dateString[0], to: dateString[1] } }})}
+            />
+        );
+    }
+
+    return (
+        <Input
+            value={value}
+            onChange={onChange}
+            placeholder={placeholder}
+            style={{width: 130, fontSize: "14px"}}
+        />
+    )
+}

--- a/src/components/common/layout/conditions/conditionbar/index.jsx
+++ b/src/components/common/layout/conditions/conditionbar/index.jsx
@@ -1,0 +1,46 @@
+import ConditionPanel from "@/src/components/common/layout/conditions/conditionPanel";
+
+export default function ConditionBar(props) {
+    const {
+        title,
+        conditions,
+        setConditions,
+        labels,
+        orderKeys,
+        options,
+        types
+    } = props;
+
+    // 조건 변경 핸들러
+    const handleConditionChange = (id, value) => {
+        setConditions((prev) => ({
+            ...prev,
+            [id]: value,
+        }));
+    };
+
+    // 조회 버튼 클릭 핸들러
+    const handleSearch = () => {
+        console.log(`Search: ${JSON.stringify(conditions)}`);
+    };
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div>
+                <h3 className="text-xl weight-700">{title}</h3>
+            </div>
+
+            <div className="border border-solid border-[#DBDBDB] rounded-md pl-1 pr-3 py-2">
+                <ConditionPanel
+                    conditions={conditions}
+                    onConditionChange={handleConditionChange}
+                    onSearch={handleSearch}
+                    labels={labels}
+                    orderKeys={orderKeys}
+                    options={options}
+                    types={types}
+                />
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## 🔎 구현한 기능
- 공통 조회조건영역 컴포넌트 구현
![Screenshot 2025-02-01 at 03 26 04](https://github.com/user-attachments/assets/f0dbacc3-f153-4f6e-8e9d-e4ba925744ad)


## 🔎 관련 이슈
closed #1 


## 🔎 사용 방법
1. conditions state 선언
- key: 각 조회조건명 (노션 위키 참조)
- value: 조회조건의 초기값 설정 (날짜, 금액은 from, to가 존재합니다. 이 부분도 노션 참조)

2. labels 객체 선언
- key: 각 조회조건명 (노션 위키 참조)
- value: 해당 조회조건의 라벨명

3. orderKeys 배열 선언
- 조회조건의 명을 원하는 순서로 나열하면 이 배열에 선언된 순서로 나열됩니다.

4. types 객체 선언
- key: 각 조회조건명 (노션 위키 참조)
- value: 각 조회조건의 필드 타입 (노션 위키 참조)

5. options 객체 선언
- key: 각 조회조건명 (노션 위키 참조)
- value: 배열 타입. 각 조회조건의 선택 옵션 지정

6. return에서 각 props와 함께 ConditionBar 컴포넌트 호출
<img width="351" alt="Screenshot 2025-02-01 at 03 34 29" src="https://github.com/user-attachments/assets/7e6751ab-61b1-4d8b-a507-42b40a9e958f" />



## 🔎 참고사항
- 본 컴포넌트는 현재 1차 완성본으로, 사용 방법은 논의 후 개선될 수 있음을 알려드립니다.
- 사용 예제 코드는 feature/budgetPlan 브랜치의 pages/budgetPlan/index.jsx 파일에서 보실 수 있습니다.


## 🔎 업데이트 예정 사항
- amount(금액) 부분의 현재 입력칸이 하나인 상태입니다. 이 부분은 추후 2개로 개선 예정입니다. (n원 부터 n원 까지)
- props drilling을 고려한 context 사용 검토