### PR TITLE
fix: layout에 존재하는 Header, Sidebar 중복 선언으로 인한 UI 중복 노출 제거

### DIFF
--- a/src/components/units/budgetPlan/BudgetPlan.container.jsx
+++ b/src/components/units/budgetPlan/BudgetPlan.container.jsx
@@ -21,7 +21,7 @@ export default function BudgetPlan() {
 
     const labels = {
         expenseType: "집행 유형",
-        clubName: "동아리명",
+        clubName: "동아리",
         paymentDate: "결제 예정일",
         status: "상태",
         content: "내용",

--- a/src/components/units/budgetPlan/BudgetPlan.presenter.jsx
+++ b/src/components/units/budgetPlan/BudgetPlan.presenter.jsx
@@ -7,44 +7,34 @@ import {useEffect, useState} from "react";
 
 export default function BudgetPlanUI({ conditions, setConditions, labels, orderKeys, options, types, defaultColumns, dataSource, setDataSource, loading, setLoading, permission1, handleAdd }) {
     return (
-        <div className="flex h-screen">
-            <div className="w-[12%]">
-                <SideBarLayout/>
-            </div>
-            <div className="flex flex-col border-l-[1px] border-solid border-black">
-                <div className="flex h-[10%]">
-                    <HeaderLayout/>
-                </div>
-                <div className="flex flex-col gap-7 border-t-[1px] border-solid border-black p-5">
-                    <ConditionBar
-                        title={"예산 계획"}
-                        conditions={conditions}
-                        setConditions={setConditions}
-                        labels={labels}
-                        orderKeys={orderKeys}
-                        options={options}
-                        types={types}
+        <div className="flex flex-col gap-7 border-t-[1px] border-solid border-black p-5">
+            <ConditionBar
+                title={"예산 계획"}
+                conditions={conditions}
+                setConditions={setConditions}
+                labels={labels}
+                orderKeys={orderKeys}
+                options={options}
+                types={types}
+            />
+
+            <div>
+                <TableWrapper
+                    title="예산 계획 현황 조회"
+                    subTitle={`${dataSource.length}건`}
+                    hasAddButton={permission1 == "admin"}
+                    handleAdd={handleAdd}
+                    width="100%">
+                    <EditableTable
+                        dataSource={dataSource}
+                        setDataSource={setDataSource}
+                        defaultColumns={defaultColumns}
+                        loading={loading}
+                        setLoading={setLoading}
+                        permission={permission1}
                     />
 
-                    <div>
-                        <TableWrapper
-                            title="예산 계획 현황 조회"
-                            subTitle={`${dataSource.length}건`}
-                            hasAddButton={permission1 == "admin"}
-                            handleAdd={handleAdd}
-                            width="100%">
-                            <EditableTable
-                                dataSource={dataSource}
-                                setDataSource={setDataSource}
-                                defaultColumns={defaultColumns}
-                                loading={loading}
-                                setLoading={setLoading}
-                                permission={permission1}
-                            />
-
-                        </TableWrapper>
-                    </div>
-                </div>
+                </TableWrapper>
             </div>
         </div>
     )


### PR DESCRIPTION
## 🔎 관련 이슈
layout에 존재하는 Header, Sidebar 중복 선언으로 인한 UI 중복 노출 제거

## 🔎 작업 내용
 layout에 존재하는 Header, Sidebar 중복 선언으로 인한 UI 중복 노출을 발견하여 개선하였습니다.

[ 개선 전 ]
<img width="1728" alt="Screenshot 2025-02-11 at 12 25 07" src="https://github.com/user-attachments/assets/2ed36237-4242-4855-92ba-d0daff0ecdea" />


[ 개선 후 ]
<img width="1721" alt="Screenshot 2025-02-11 at 12 25 22" src="https://github.com/user-attachments/assets/9c72f60d-13ba-4c83-8ca7-2fb7bbc39454" />





