### PR TITLE
feat: 예산 사용내역 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "next-transpile-modules": "^10.0.1",
     "react": "^18",
     "react-dom": "^18",
-    "react-redux": "^9.2.0"
+    "react-redux": "^9.2.0",
     "styled-components": "^6.1.14",
     "uuid": "^11.0.5"
   },

--- a/pages/budgetUsage/index.jsx
+++ b/pages/budgetUsage/index.jsx
@@ -1,0 +1,5 @@
+import BudgetUsage from "@/src/components/units/budgetUsage/BudgetUsage.container";
+
+export default function BudgetUsagePage() {
+  return <BudgetUsage />;
+}

--- a/src/components/common/layout/table/editableTable/index.jsx
+++ b/src/components/common/layout/table/editableTable/index.jsx
@@ -5,7 +5,7 @@ import dayjs from 'dayjs';
 import EditableCell from '../tableCell';
 import HeaderCell from '../tableHeader';
 import EditableRow from '../tableRow';
-const EditableTable = ({dataSource, setDataSource,defaultColumns,loading,setLoading,permission}) => {
+const EditableTable = ({dataSource, setDataSource,defaultColumns,loading,setLoading,selected,setSelected,permission}) => {
     // 페이지네이션 현재 페이지
     const [currentPage,setCurrentPage] = useState(1);
     const isAdmin = permission=="admin";
@@ -53,14 +53,15 @@ const EditableTable = ({dataSource, setDataSource,defaultColumns,loading,setLoad
                 dataIndex: col.dataIndex,
                 type: col.type,
                 selects: col.selects,
+                selectboxWidth: col.selectboxWidth,
                 maxlength: col.maxlength,
-                handleSave,
+                handleSave
             }),
         };
     });
 
     const [pageSize,setPageSize] = useState(5); // 한 페이지당 항목 수
-    const [selected,setSelected] = useState(-1);
+    
     const onRowClick = (index)=>{
         setSelected(selected==index?-1:index);//토글
     }
@@ -189,13 +190,13 @@ const EditableTable = ({dataSource, setDataSource,defaultColumns,loading,setLoad
         return pages;
     };
     return (
-        <div className='flex flex-col gap-4'>
+        <div className='flex flex-col gap-4 w-full'>
             {/* 행 추가 버튼 */}
             {/* <Button onClick={handleAdd} type="primary" className='mb-4'>행 추가</Button> */}
             <Table
                 className={`rounded-md bg-white border border-gray-300 h-[346px] overflow-hidden`}
                 components={components}
-                rowClassName={() => 'editable-row'}
+                rowClassName={() => 'editable-row cursor-pointer'}
                 bordered={false}
                 dataSource={dataSource.slice((currentPage - 1) * pageSize, currentPage * pageSize)}
                 columns={columns}
@@ -205,7 +206,7 @@ const EditableTable = ({dataSource, setDataSource,defaultColumns,loading,setLoad
                     record,
                     index:rowIndex,
                     onRowClick,
-                    className: rowIndex==selected?"bg-gray-100":"",
+                    className: rowIndex==selected?"bg-gray-100 font-semibold":"",
                 })}/>
             <div className='flex justify-center items-center'>
                 <div className='flex gap-2'>

--- a/src/components/common/layout/table/tableCell/index.jsx
+++ b/src/components/common/layout/table/tableCell/index.jsx
@@ -240,6 +240,30 @@ const EditableCell = ({
                 </div>
             );
         }
+        else if(type=='number'){
+            childNode = editing ? (
+                <Form.Item name={dataIndex} className="m-0">
+                    <Input
+            ref={inputRef}
+            onPressEnter={save}
+            onBlur={save}
+            maxLength={maxlength}
+            inputMode="numeric"
+            className="text-center"
+            onKeyDown={(e) => {
+                if(e.key.match(/[^0-9]/g)){
+                    setTimeout(()=>{e.target.value =  e.target.value.replace(/[^0-9]/g, '');},10)
+                }
+            }}
+            type="text"
+        />
+                </Form.Item>
+            ) : (
+                <div onClick={toggleEdit} className="text-center cursor-pointer text-[16px] w-full min-h-[16px]">
+                    {children}
+                </div>
+            );
+        }
         else if(type=='text'){
             childNode = editing ? (
                 <Form.Item name={dataIndex} className="m-0">

--- a/src/components/common/layout/table/tableCell/index.jsx
+++ b/src/components/common/layout/table/tableCell/index.jsx
@@ -13,6 +13,7 @@ const EditableCell = ({
     dataIndex,
     record,
     selects,
+    selectboxWidth,
     handleSave,
     children,
     ...restProps
@@ -199,6 +200,7 @@ const EditableCell = ({
                         onBlur={() => {
                             toggleEdit(); // 포커스 아웃 시 편집 종료
                         }}
+                        style={{width:selectboxWidth}}
                     >
                         {selects.map((data) => (
                             <Select.Option key={data} value={data}>

--- a/src/components/common/layout/table/tableCell/index.jsx
+++ b/src/components/common/layout/table/tableCell/index.jsx
@@ -232,7 +232,7 @@ const EditableCell = ({
         />
                 </Form.Item>
             ) : (
-                <div onClick={toggleEdit} className=" text-center cursor-pointer text-[16px]">
+                <div onClick={toggleEdit} className=" text-center cursor-pointer text-[16px] w-full min-h-[16px]">
                     {/* 천단위 구분 표시 */}
                     {Number(children[1]).toLocaleString()}
                 </div>
@@ -244,7 +244,7 @@ const EditableCell = ({
                     <Input ref={inputRef} onPressEnter={save} onBlur={save} maxLength={maxlength} className="text-center"/>
                 </Form.Item>
             ) : (
-                <div onClick={toggleEdit} className="text-center cursor-pointer text-[16px]">
+                <div onClick={toggleEdit} className="text-center cursor-pointer text-[16px] w-full min-h-[16px]">
                     {children}
                 </div>
             );

--- a/src/components/common/layout/table/tableWrapper/index.jsx
+++ b/src/components/common/layout/table/tableWrapper/index.jsx
@@ -1,5 +1,5 @@
 import { Button } from 'antd';
-function TableWrapper({ title,subTitle,width,hasAddButton,handleAdd, children }) {
+function TableWrapper({ title,subTitle,width,hasAddButton,handleAdd,handleAddTitle, children }) {
     return (
         <div className={`flex flex-col gap-2`} style={{width:width}}>
             <div className="flex flex-row justify-between">
@@ -7,7 +7,7 @@ function TableWrapper({ title,subTitle,width,hasAddButton,handleAdd, children })
                     <p className="font-semibold text-[18px]">{title}</p>
                     <p className="font-medium text-[16px] text-[#3A3A3A] leading-[30px]">{subTitle}</p>
                 </div>
-                {hasAddButton&&<Button onClick={handleAdd} type="primary" className='bg-[#4368BA]'>추가</Button>}
+                {hasAddButton&&<Button onClick={handleAdd} type="primary" className='bg-[#4368BA]'>{handleAddTitle}</Button>}
             </div>
             <div className="w-full">
                 {children}

--- a/src/components/units/budgetPlan/BudgetPlan.container.jsx
+++ b/src/components/units/budgetPlan/BudgetPlan.container.jsx
@@ -21,7 +21,7 @@ export default function BudgetPlan() {
 
     const labels = {
         expenseType: "집행 유형",
-        clubName: "동아리명",
+        clubName: "동아리",
         paymentDate: "결제 예정일",
         status: "상태",
         content: "내용",

--- a/src/components/units/budgetPlan/BudgetPlan.presenter.jsx
+++ b/src/components/units/budgetPlan/BudgetPlan.presenter.jsx
@@ -7,44 +7,34 @@ import {useEffect, useState} from "react";
 
 export default function BudgetPlanUI({ conditions, setConditions, labels, orderKeys, options, types, defaultColumns, dataSource, setDataSource, loading, setLoading, permission1, handleAdd }) {
     return (
-        <div className="flex h-screen">
-            <div className="w-[12%]">
-                <SideBarLayout/>
-            </div>
-            <div className="flex flex-col border-l-[1px] border-solid border-black">
-                <div className="flex h-[10%]">
-                    <HeaderLayout/>
-                </div>
-                <div className="flex flex-col gap-7 border-t-[1px] border-solid border-black p-5">
-                    <ConditionBar
-                        title={"예산 계획"}
-                        conditions={conditions}
-                        setConditions={setConditions}
-                        labels={labels}
-                        orderKeys={orderKeys}
-                        options={options}
-                        types={types}
+        <div className="flex flex-col gap-7 border-t-[1px] border-solid border-black p-5">
+            <ConditionBar
+                title={"예산 계획"}
+                conditions={conditions}
+                setConditions={setConditions}
+                labels={labels}
+                orderKeys={orderKeys}
+                options={options}
+                types={types}
+            />
+
+            <div>
+                <TableWrapper
+                    title="예산 계획 현황 조회"
+                    subTitle={`${dataSource.length}건`}
+                    hasAddButton={permission1 == "admin"}
+                    handleAdd={handleAdd}
+                    width="100%">
+                    <EditableTable
+                        dataSource={dataSource}
+                        setDataSource={setDataSource}
+                        defaultColumns={defaultColumns}
+                        loading={loading}
+                        setLoading={setLoading}
+                        permission={permission1}
                     />
 
-                    <div>
-                        <TableWrapper
-                            title="예산 계획 현황 조회"
-                            subTitle={`${dataSource.length}건`}
-                            hasAddButton={permission1 == "admin"}
-                            handleAdd={handleAdd}
-                            width="100%">
-                            <EditableTable
-                                dataSource={dataSource}
-                                setDataSource={setDataSource}
-                                defaultColumns={defaultColumns}
-                                loading={loading}
-                                setLoading={setLoading}
-                                permission={permission1}
-                            />
-
-                        </TableWrapper>
-                    </div>
-                </div>
+                </TableWrapper>
             </div>
         </div>
     )

--- a/src/components/units/budgetUsage/BudgetUsage.container.jsx
+++ b/src/components/units/budgetUsage/BudgetUsage.container.jsx
@@ -1,0 +1,220 @@
+import BudgetUsageUI from "@/src/components/units/budgetUsage/BudgetUsage.presenter";
+import {useEffect, useState} from "react";
+import dayjs from "dayjs";
+
+export default function BudgetUsage() {
+    const today = new Date();
+    const todayString = today.toISOString().split("T")[0];
+    const lastMonth = new Date(today.setMonth(today.getMonth() - 1));
+    const lastMonthString = lastMonth.toISOString().split("T")[0];
+
+    const [conditions, setConditions] = useState({
+        expenseType: "운영비",
+        clubName: "개발 동아리",
+        paymentDate: {from: lastMonthString, to: todayString},
+        paymentType: "카드",
+        status: "대기",
+        content: "",
+        drafter: "",
+        amount: {from: 0, to: 5000000}
+    });
+
+    const labels = {
+        expenseType: "집행 유형",
+        clubName: "동아리",
+        paymentDate: "결제일",
+        paymentType: "결제 방법",
+        content: "내용",
+        status: "상태",
+        drafter: "기안자",
+        amount: "금액"
+    };
+
+    const orderKeys = [
+        "expenseType",
+        "clubName",
+        "paymentDate",
+        "paymentType",
+        "content",
+        "amount",
+        "drafter",
+        "status",
+    ];
+
+    const types = {
+        expenseType: "select",
+        clubName: "selectWithSearch",
+        paymentDate: "rangeDate",
+        paymentType: "select",
+        status: "select",
+        content: "text",
+        drafter: "text",
+        amount: "number"
+    }
+
+    const options = {
+        expenseType: ["운영비", "행사비", "소모품 구매"],
+        paymentType: ["카드", "현금", "무통장입금"],
+        status: ["대기", "승인", "반려"],
+        clubName: ["빅데이터 동아리", "머신러닝 동아리", "개발 동아리"]
+    }
+
+    const defaultColumns = [
+        {
+            title: 'No',
+            dataIndex: 'No',
+            width: '1%',
+            editable: false,
+            type:'id'
+        },
+        {
+            title: '집행유형',
+            dataIndex: 'executionType',
+            width: '5%',
+            editable: true,
+            type:'select',
+            selects:['소모품 구매','운영비','행사비']
+        },
+        {
+            title:'동아리',
+            dataIndex: 'clubName',
+            width: '5%',
+            editable: true,
+            type:'select',
+            selects: ['빅데이터 동아리', '머신러닝 동아리', '개발 동아리']
+        },
+        {
+            title:'내용',
+            dataIndex: 'content',
+            width: '12%',
+            editable: true,
+            type:'text',
+            maxlength: 30
+        },
+        {
+            title:'기안자',
+            dataIndex: 'drafter',
+            width: '5%',
+            editable: true,
+            type:'text',
+            maxlength: 5
+        },
+        {
+            title: '결제 방법',
+            dataIndex: 'paymentType',
+            width: '5%',
+            editable: true,
+            type:'select',
+            selects:["카드", "현금", "무통장입금"],
+        },
+        {
+            title:'결제일',
+            dataIndex: 'paymentDate',
+            width: '5%',
+            editable: true,
+            type:'date',
+        },
+        {
+            title:'금액',
+            dataIndex: 'amount',
+            width: '1%',
+            editable: true,
+            type:'money',
+            maxlength:10000000
+        },
+        {
+            title:'상태',
+            dataIndex: 'status',
+            width: '1%',
+            editable: true,
+            type:'select',
+            selects:['대기', '승인', '반려']
+        },
+        {
+            title: '첨부파일',
+            dataIndex: 'attachment',
+            width: '3%',
+            editable: false,
+            type: 'text'
+        }
+    ];
+
+    const [dataSource, setDataSource] = useState([]);
+    const [count, setCount] = useState(null);
+    const [loading, setLoading] = useState(true);
+
+    // 데이터 요청 함수
+    const fetchData = async () => {
+        try{
+            setLoading(true);
+            // 임의의 API 호출(여기서 API 연결)
+            const response = await axios.get('https://jsonplaceholder.typicode.com/users');
+            const baseData = response.data;
+
+            // 임의로 100개의 데이터 생성
+            const data = Array.from({ length: 100 }, (_, index) => {
+                const item = baseData[index % baseData.length]; // 데이터 순환
+                return {
+                    No: index + 1,
+                    executionType: '소모품 구매',
+                    clubName: '빅데이터 동아리',
+                    content: '',
+                    drafter: '',
+                    paymentType: ['카드', '현금', '무통장입금'][index % 3],
+                    paymentDate: dayjs().add(index, 'day').format('YYYY-MM-DD'), // 날짜를 하루씩 증가
+                    amount: 0,
+                    status: ['대기', '승인', '반려'][index % 3],
+                    attachment: '',
+                };
+            });
+
+            setDataSource(data);
+            setCount(data.length);
+        }
+        catch(error){
+            console.error('데이터 로딩 실패:', error);
+        }
+        finally{
+            setLoading(false);
+        }
+    };
+
+    const handleAdd = () => {
+        const newData = defaultColumns.reduce((acc, column) => {
+            const { dataIndex, type } = column;
+            if (type === 'text') acc[dataIndex] = '';
+            else if (type === 'select') acc[dataIndex] = column.selects ? column.selects[0] : '';
+            else if (type === 'date') acc[dataIndex] = dayjs().format('YYYY-MM-DD'); // 현재 날짜
+            else if (type === 'file') acc[dataIndex] = null;
+            else if (type === 'id') acc[dataIndex] = count + 1; // No 필드 자동 증가
+            else if (type === 'money') acc[dataIndex] = 0; // No 필드 자동 증가
+            else acc[dataIndex] = ''; // 나머지는 빈 문자열로 초기화
+            return acc;
+        }, {});
+        setDataSource([...dataSource, newData]);
+        setCount(count + 1);
+    };
+
+    // 컴포넌트 마운트 시 데이터 로드
+    useEffect(() => {
+        fetchData();
+    }, []);
+
+    const permission1 = "admin";
+
+    return <BudgetUsageUI
+        conditions={conditions}
+        setConditions={setConditions}
+        labels={labels}
+        orderKeys={orderKeys}
+        options={options}
+        types={types}
+        dataSource={dataSource}
+        setDataSource={setDataSource}
+        defaultColumns={defaultColumns}
+        loading={loading}
+        setLoading={setLoading}
+        handleAdd={handleAdd}
+        permission1={permission1}
+    />;
+}

--- a/src/components/units/budgetUsage/BudgetUsage.container.jsx
+++ b/src/components/units/budgetUsage/BudgetUsage.container.jsx
@@ -135,8 +135,8 @@ export default function BudgetUsage() {
             title: '첨부파일',
             dataIndex: 'attachment',
             width: '3%',
-            editable: false,
-            type: 'text'
+            editable: true,
+            type: 'file'
         }
     ];
 

--- a/src/components/units/budgetUsage/BudgetUsage.container.jsx
+++ b/src/components/units/budgetUsage/BudgetUsage.container.jsx
@@ -1,6 +1,7 @@
 import BudgetUsageUI from "@/src/components/units/budgetUsage/BudgetUsage.presenter";
 import {useEffect, useState} from "react";
 import dayjs from "dayjs";
+import axios from "axios";
 
 export default function BudgetUsage() {
     const today = new Date();
@@ -143,17 +144,15 @@ export default function BudgetUsage() {
     const [count, setCount] = useState(null);
     const [loading, setLoading] = useState(true);
 
-    // 데이터 요청 함수
+    // 데이터 요청 함수 - 백엔드 개발 후 대체 필요
     const fetchData = async () => {
         try{
             setLoading(true);
-            // 임의의 API 호출(여기서 API 연결)
             const response = await axios.get('https://jsonplaceholder.typicode.com/users');
             const baseData = response.data;
 
-            // 임의로 100개의 데이터 생성
             const data = Array.from({ length: 100 }, (_, index) => {
-                const item = baseData[index % baseData.length]; // 데이터 순환
+                const item = baseData[index % baseData.length];
                 return {
                     No: index + 1,
                     executionType: '소모품 구매',
@@ -161,7 +160,7 @@ export default function BudgetUsage() {
                     content: '',
                     drafter: '',
                     paymentType: ['카드', '현금', '무통장입금'][index % 3],
-                    paymentDate: dayjs().add(index, 'day').format('YYYY-MM-DD'), // 날짜를 하루씩 증가
+                    paymentDate: dayjs().add(index, 'day').format('YYYY-MM-DD'),
                     amount: 0,
                     status: ['대기', '승인', '반려'][index % 3],
                     attachment: '',
@@ -184,11 +183,11 @@ export default function BudgetUsage() {
             const { dataIndex, type } = column;
             if (type === 'text') acc[dataIndex] = '';
             else if (type === 'select') acc[dataIndex] = column.selects ? column.selects[0] : '';
-            else if (type === 'date') acc[dataIndex] = dayjs().format('YYYY-MM-DD'); // 현재 날짜
+            else if (type === 'date') acc[dataIndex] = dayjs().format('YYYY-MM-DD');
             else if (type === 'file') acc[dataIndex] = null;
-            else if (type === 'id') acc[dataIndex] = count + 1; // No 필드 자동 증가
-            else if (type === 'money') acc[dataIndex] = 0; // No 필드 자동 증가
-            else acc[dataIndex] = ''; // 나머지는 빈 문자열로 초기화
+            else if (type === 'id') acc[dataIndex] = count + 1;
+            else if (type === 'money') acc[dataIndex] = 0;
+            else acc[dataIndex] = '';
             return acc;
         }, {});
         setDataSource([...dataSource, newData]);

--- a/src/components/units/budgetUsage/BudgetUsage.presenter.jsx
+++ b/src/components/units/budgetUsage/BudgetUsage.presenter.jsx
@@ -1,0 +1,38 @@
+import ConditionBar from "@/src/components/common/layout/conditions/conditionbar";
+import TableWrapper from "@/src/components/common/layout/table/tableWrapper";
+import EditableTable from "@/src/components/common/layout/table/editableTable";
+
+export default function BudgetUsageUI({ conditions, setConditions, labels, orderKeys, options, types, defaultColumns, dataSource, setDataSource, loading, setLoading, permission1, handleAdd }) {
+
+  return (
+      <div className="flex flex-col gap-7 border-t-[1px] border-solid border-black p-5">
+          <ConditionBar
+              title={"예산 사용내역"}
+              conditions={conditions}
+              setConditions={setConditions}
+              labels={labels}
+              orderKeys={orderKeys}
+              options={options}
+              types={types}
+          />
+
+          <div>
+              <TableWrapper
+                  title="예산 사용내역 조회"
+                  subTitle={`${dataSource.length}건`}
+                  handleAdd={handleAdd}
+                  width="100%">
+                  <EditableTable
+                      dataSource={dataSource}
+                      setDataSource={setDataSource}
+                      defaultColumns={defaultColumns}
+                      loading={loading}
+                      setLoading={setLoading}
+                      permission={permission1}
+                  />
+
+              </TableWrapper>
+          </div>
+      </div>
+  );
+}


### PR DESCRIPTION
## 🔎 관련 이슈
close #21

## 🔎 작업 내용
- 조회조건 속성 매칭
- 테이블 컬럼 매칭
<img width="1570" alt="Screenshot 2025-02-11 at 14 02 06" src="https://github.com/user-attachments/assets/1f9ca63b-495a-48dc-b465-8c71b3f0f832" />


## 🔎 참고사항
- 조회조건의 금액 라벨인 "number" 속성의 범위 입력이 가능하도록 조회조건 컴포넌트 개선 예정
- 조회조건의 범위를 설정할 때 to는 from보다 이전일 수 없도록 제한 예정

## 🗣️ 요청사항
@lh7721004 
첨부파일 type의 테이블 컬럼 지정이 없으니, 업데이트 이슈에 추가 부탁드립니다!!
<img width="207" alt="Screenshot 2025-02-11 at 14 09 34" src="https://github.com/user-attachments/assets/2edee461-c847-4ec0-8fb3-4f2441eeefbb" />



