### PR TITLE
update: EditableTable 행 선택 개선 및 넘칠 시 스크롤 추가, 행 개수 7개로 조정

### DIFF
--- a/src/components/common/layout/table/editableTable/index.jsx
+++ b/src/components/common/layout/table/editableTable/index.jsx
@@ -196,7 +196,7 @@ const EditableTable = ({dataSource, setDataSource,defaultColumns,loading,setLoad
             {/* 행 추가 버튼 */}
             {/* <Button onClick={handleAdd} type="primary" className='mb-4'>행 추가</Button> */}
             <Table
-                className={`rounded-md bg-white border border-gray-300 h-[346px] overflow-hidden`}
+                className={`rounded-md bg-white border border-gray-300 h-[350px] overflow-auto`}
                 components={components}
                 rowClassName={() => 'editable-row cursor-pointer'}
                 bordered={false}

--- a/src/components/common/layout/table/editableTable/index.jsx
+++ b/src/components/common/layout/table/editableTable/index.jsx
@@ -63,7 +63,7 @@ const EditableTable = ({dataSource, setDataSource,defaultColumns,loading,setLoad
     const [pageSize,setPageSize] = useState(5); // 한 페이지당 항목 수
     
     const onRowClick = (index)=>{
-        setSelected(selected==index?-1:index);//토글
+        setSelected(index);
     }
     const totalPages = dataSource&&dataSource.length!=0?Math.ceil(dataSource.length / pageSize):0; // 전체 페이지 수
 

--- a/src/components/common/layout/table/editableTable/index.jsx
+++ b/src/components/common/layout/table/editableTable/index.jsx
@@ -60,7 +60,7 @@ const EditableTable = ({dataSource, setDataSource,defaultColumns,loading,setLoad
         };
     });
 
-    const [pageSize,setPageSize] = useState(5); // 한 페이지당 항목 수
+    const [pageSize,setPageSize] = useState(7); // 한 페이지당 항목 수
     
     const onRowClick = (index)=>{
         setSelected(index);
@@ -196,7 +196,7 @@ const EditableTable = ({dataSource, setDataSource,defaultColumns,loading,setLoad
             {/* 행 추가 버튼 */}
             {/* <Button onClick={handleAdd} type="primary" className='mb-4'>행 추가</Button> */}
             <Table
-                className={`rounded-md bg-white border border-gray-300 h-[350px] overflow-auto`}
+                className={`rounded-md bg-white border border-gray-300 h-[464px] overflow-auto`}
                 components={components}
                 rowClassName={() => 'editable-row cursor-pointer'}
                 bordered={false}


### PR DESCRIPTION
## 🔎 관련 이슈
#45 
#48 

## 🔎 작업 내용
- 행 높이 초과시 scroll로 더 보기
- 행 클릭 이벤트시 토글이 아닌 일반 선택으로 변경
- 테이블당 행 개수 7개로 조정


## 🔎 참고사항
![image](https://github.com/user-attachments/assets/77bf02bc-2588-4f33-8dfb-7019f3cab5d4)



