### PR TITLE
update: 빈 테이블 표시에 테이블 높이에 맞지 않는 아이콘 위치 조정

### DIFF
--- a/src/components/common/layout/table/editableTable/index.jsx
+++ b/src/components/common/layout/table/editableTable/index.jsx
@@ -5,6 +5,8 @@ import dayjs from 'dayjs';
 import EditableCell from '../tableCell';
 import HeaderCell from '../tableHeader';
 import EditableRow from '../tableRow';
+import { Empty } from "antd";
+
 const EditableTable = ({dataSource, setDataSource,defaultColumns,loading,setLoading,selected,setSelected,permission}) => {
     // 페이지네이션 현재 페이지
     const [currentPage,setCurrentPage] = useState(1);
@@ -209,7 +211,15 @@ const EditableTable = ({dataSource, setDataSource,defaultColumns,loading,setLoad
                     index:rowIndex,
                     onRowClick,
                     className: rowIndex==selected?"bg-gray-100 font-semibold":"",
-                })}/>
+                })}
+                locale={{
+                    emptyText: (
+                        <div className="flex flex-col items-center justify-center text-gray-400 h-[374px]">
+                            <Empty description={"현재 조회된 데이터가 없습니다."}/>
+                        </div>
+                    ),
+                }}
+                />
             <div className='flex justify-center items-center'>
                 <div className='flex gap-2'>
                     {renderPagination(currentPage,totalPages)} {/* 커스텀 페이지네이션 */}


### PR DESCRIPTION
## 🔎 관련 이슈
#52 

## 🔎 작업 내용
빈 테이블 표시에 테이블 높이에 맞지 않는 아이콘 위치 조정


## 🔎 참고사항
![image](https://github.com/user-attachments/assets/a7e3088a-d1d6-4fec-a5a4-6896b4d7de2a)
개선 전

![image](https://github.com/user-attachments/assets/9a4ba131-65b0-4df9-b1b6-6d3abe85c6ad)
개선 후


