### PR TITLE
feat: 조회조건 영역 숫자 범위 컴포넌트 추가 - rangeNumber

### DIFF
--- a/src/components/common/layout/conditions/conditionPicker/index.jsx
+++ b/src/components/common/layout/conditions/conditionPicker/index.jsx
@@ -43,6 +43,44 @@ export default function ConditionPicker(props) {
         );
     }
 
+    if (type === "rangeNumber") {
+        const {from, to} = value;
+
+        return (
+            <Input.Group compact>
+                <InputNumber
+                    type="number"
+                    defaultValue={from}
+                    onChange={(value) => onChange({ target: { value: { from: value, to } }})}
+                    min={min}
+                    max={max}
+                    style={{width: 110, fontSize: "14px", borderRight: 0}}
+                />
+                <Input
+                    style={{
+                        width: 30,
+                        borderLeft: 0,
+                        borderRight: 0,
+                        borderLeftWidth: 0,
+                        borderRightWidth: 0,
+                        pointerEvents: 'none',
+                        backgroundColor: '#fff',
+                    }}
+                    placeholder="~"
+                    disabled
+                />
+                <InputNumber
+                    type="number"
+                    defaultValue={to}
+                    onChange={(value) => onChange({ target: { value: { from, to: value } }})}
+                    min={min}
+                    max={max}
+                    style={{width: 110, fontSize: "14px", borderLeft: 0}}
+                />
+            </Input.Group>
+        );
+    }
+
     if (type === "selectWithSearch") {
         return (
             <Select

--- a/src/components/common/layout/conditions/conditionPicker/index.jsx
+++ b/src/components/common/layout/conditions/conditionPicker/index.jsx
@@ -44,7 +44,7 @@ export default function ConditionPicker(props) {
     }
 
     if (type === "rangeNumber") {
-        const {from, to} = value;
+        const {from, to, maxNum} = value;
 
         return (
             <Input.Group compact>
@@ -53,7 +53,7 @@ export default function ConditionPicker(props) {
                     defaultValue={from}
                     onChange={(value) => onChange({ target: { value: { from: value, to } }})}
                     min={min}
-                    max={max}
+                    max={maxNum}
                     style={{width: 110, fontSize: "14px", borderRight: 0}}
                 />
                 <Input
@@ -74,7 +74,7 @@ export default function ConditionPicker(props) {
                     defaultValue={to}
                     onChange={(value) => onChange({ target: { value: { from, to: value } }})}
                     min={min}
-                    max={max}
+                    max={maxNum}
                     style={{width: 110, fontSize: "14px", borderLeft: 0}}
                 />
             </Input.Group>

--- a/src/components/common/layout/conditions/conditionbar/index.jsx
+++ b/src/components/common/layout/conditions/conditionbar/index.jsx
@@ -30,7 +30,7 @@ export default function ConditionBar(props) {
                 <h3 className="text-xl weight-700">{title}</h3>
             </div>
 
-            <div className="border border-solid border-[#DBDBDB] rounded-md pl-1 pr-3 py-2">
+            <div className="border border-solid border-[#DBDBDB] rounded-md pl-1 pr-3 py-2 bg-white">
                 <ConditionPanel
                     conditions={conditions}
                     onConditionChange={handleConditionChange}

--- a/src/components/units/budgetPlan/BudgetPlan.container.jsx
+++ b/src/components/units/budgetPlan/BudgetPlan.container.jsx
@@ -49,7 +49,7 @@ export default function BudgetPlan() {
         content: "text",
         draftDate: "rangeDate",
         drafter: "text",
-        amount: "number"
+        amount: "rangeNumber"
     }
 
     const options = {

--- a/src/components/units/budgetPlan/BudgetPlan.container.jsx
+++ b/src/components/units/budgetPlan/BudgetPlan.container.jsx
@@ -16,7 +16,7 @@ export default function BudgetPlan() {
         content: "",
         draftDate: {from: todayString, to: lastMonthString},
         drafter: "",
-        amount: {from: 0, to: 5000000}
+        amount: {from: 0, to: 100000, maxNum: 100000}
     });
 
     const labels = {


### PR DESCRIPTION
## 🔎 관련 이슈
#12 

## 🔎 작업 내용
조회조건 영역 숫자 범위 컴포넌트 추가 - rangeNumber
![Screenshot 2025-02-23 at 12 42 06](https://github.com/user-attachments/assets/3877775c-3c47-428a-a48d-ad6252c57754)



## 🔎 참고사항
사용 방법은 아래와 같습니다.

1. `conditions` state 정의시 from, to, maxNum 지정 
- from, to: UI에 노출될 초기 숫자를 의미합니다.
- maxNum: 최대로 입력할 수 있는 숫자를 지정합니다.
<img width="595" alt="Screenshot 2025-02-23 at 12 41 01" src="https://github.com/user-attachments/assets/5a21b87c-9e61-4269-8222-5dca660e3198" />


2. `const type` 정의 영역에서 `"rangeNumber"` 지정


<img width="368" alt="Screenshot 2025-02-23 at 12 30 44" src="https://github.com/user-attachments/assets/c7c4d4f0-c038-46af-8264-f05be0e0fb0f" />

