### PR TITLE
feat & fix: 예산보고서 모달 ui 구현 및 상태 추가

### DIFF
--- a/src/components/common/modals/BudgetReport/BudgetReportModal.js
+++ b/src/components/common/modals/BudgetReport/BudgetReportModal.js
@@ -1,0 +1,70 @@
+import React from "react";
+
+export default function BudgetReportModal({ report, onClose }) {
+    const approvalLine = [
+        { id: 1, step: 1, position: "관리자", approver: "김철수", status: "승인" },
+        { id: 2, step: 2, position: "회장", approver: "홍길동", status: "승인" },
+    ];
+
+    // 모달 바깥 클릭 시 닫기
+    const handleOverlayClick = (e) => {
+        if (e.target.id === "modal-overlay") {
+            onClose();
+        }
+    };
+
+    return (
+        <div
+            id="modal-overlay"
+            className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+            onClick={handleOverlayClick}
+        >
+            <div className="bg-white w-[600px] max-w-[90%] rounded-lg shadow-lg overflow-hidden relative">
+
+                {/* 모달 헤더 */}
+                <div className="bg-gradient-to-r from-[#4A96EC] to-[#237BE6] to-blue-600 text-white p-4 text-lg font-bold flex justify-between items-center">
+                    <span>예산 보고서</span>
+                    {/* X 버튼 */}
+                    <button onClick={onClose} className="text-white text-2xl font-bold">
+                        ✕
+                    </button>
+                </div>
+
+                {/* 파일 업로드 영역 (보고서 파일 확인) */}
+                <div className="p-6 flex flex-col items-center justify-center h-[400px] border-b border-gray-300">
+                    <p className="text-gray-500">보고서 파일을 확인하세요</p>
+                    <p className="text-gray-400 text-sm">(스크롤 가능 영역)</p>
+                </div>
+
+                {/* 결재 라인 */}
+                <div className="p-4 bg-[#F7F7F7]">
+                    <span className="text-gray-700 font-bold mb-2 block">결재 라인</span>
+                    <div className="bg-white rounded-md shadow">
+                        <table className="w-full border border-gray-300 rounded-md">
+                            <thead className="bg-white-100">
+                            <tr className="text-gray-700">
+                                <th className="p-2 border">단계</th>
+                                <th className="p-2 border">직위</th>
+                                <th className="p-2 border">결재자</th>
+                                <th className="p-2 border">상태</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {approvalLine.map((item) => (
+                                <tr key={item.id} className="text-center bg-white">
+                                    <td className="p-2 border">{item.step}</td>
+                                    <td className="p-2 border">{item.position}</td>
+                                    <td className="p-2 border">{item.approver}</td>
+                                    <td className={`p-2 border ${item.status === "승인" ? "text-green-600" : "text-yellow-600"}`}>
+                                        {item.status}
+                                    </td>
+                                </tr>
+                            ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/units/budgetReport/BudgetReport.container.jsx
+++ b/src/components/units/budgetReport/BudgetReport.container.jsx
@@ -1,4 +1,5 @@
 import BudgetUsageUI from "@/src/components/units/budgetReport/BudgetReport.presenter";
+import BudgetReportModal from "@/src/components/common/modals/BudgetReport/BudgetReportModal"; // 모달 경로 추가
 import {useEffect, useState} from "react";
 import dayjs from "dayjs";
 import axios from "axios";
@@ -122,6 +123,7 @@ export default function BudgetReport() {
     const [dataSource, setDataSource] = useState([]);
     const [count, setCount] = useState(null);
     const [loading, setLoading] = useState(true);
+    const [selectedReport, setSelectedReport] = useState(null); // 모달 표시 데이터 상태 추가
 
     // 데이터 요청 함수 - 백엔드 개발 후 대체 필요
     const fetchData = async () => {
@@ -176,9 +178,22 @@ export default function BudgetReport() {
         fetchData();
     }, []);
 
+    // 행 더블 클릭 시 모달 열기
+    const handleRowDoubleClick = (record) => {
+        setSelectedReport(record);
+    };
+
+    // 모달 닫기
+    const handleCloseModal = () => {
+        setSelectedReport(null);
+    };
+
+
     const permission1 = "admin";
 
-    return <BudgetUsageUI
+    return (
+        <>
+            <BudgetUsageUI
         conditions={conditions}
         setConditions={setConditions}
         labels={labels}
@@ -192,5 +207,13 @@ export default function BudgetReport() {
         setLoading={setLoading}
         handleAdd={handleAdd}
         permission1={permission1}
-    />;
+        onRowDoubleClick={handleRowDoubleClick} // 모달 handle 추가
+             />
+
+            {/* 모달 추가 */}
+            {selectedReport && (
+                <BudgetReportModal report={selectedReport} onClose={handleCloseModal} />
+            )}
+        </>
+    );
 }

--- a/src/components/units/budgetReport/BudgetReport.presenter.jsx
+++ b/src/components/units/budgetReport/BudgetReport.presenter.jsx
@@ -2,7 +2,9 @@ import ConditionBar from "@/src/components/common/layout/conditions/conditionbar
 import TableWrapper from "@/src/components/common/layout/table/tableWrapper";
 import EditableTable from "@/src/components/common/layout/table/editableTable";
 
-export default function BudgetReportUI({ conditions, setConditions, labels, orderKeys, options, types, defaultColumns, dataSource, setDataSource, loading, setLoading, permission1, handleAdd }) {
+export default function BudgetReportUI({ conditions, setConditions, labels, orderKeys, options,
+                                           types, defaultColumns, dataSource, setDataSource, loading,
+                                           setLoading, permission1, handleAdd, onRowDoubleClick, }) {
     return (
         <div className="flex flex-col gap-7 p-5">
             <ConditionBar
@@ -29,6 +31,7 @@ export default function BudgetReportUI({ conditions, setConditions, labels, orde
                         setLoading={setLoading}
                         permission={permission1}
                         setSelected={() => { }}
+                        onRowDoubleClick={onRowDoubleClick} // 모달 더블 클릭 추가
                     />
 
                 </TableWrapper>


### PR DESCRIPTION
## 🔎 관련 이슈
feat & fix: 예산보고서 모달 ui 구현 및 상태 추가

## 🔎 작업 내용
budgetreport 모달 구현
파일 보고서 영역 및 결재 라인 ui 구현

![스크린샷 2025-03-15 오후 9 49 00](https://github.com/user-attachments/assets/f01df063-f7a0-4481-bf40-79a36133d7d0)

## 🔎 참고사항
파일보고서 영역은 회의후 hwp, excel 등 결정되면 추가 구현예정
결재라인은 벡엔드 entity 결정후 받아올 예정
budgetreport container 와 presenter는 모달 관련해서만 수정함

