### PR TITLE
update: 화면 세로 길이 줄일 시 요소 찌그러짐 오류 개선

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,45 +1,45 @@
+'use client';
+
 import "@/styles/globals.css";
 import { Provider } from "react-redux";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import store from "../redux/store";
 import SideBarLayout from "@/src/components/common/layout/sidebar";
 import HeaderLayout from "@/src/components/common/layout/header";
+import { useRouter } from "next/router";
 
 const queryClient = new QueryClient();
 
 export default function App({ Component, pageProps }) {
-    const getLayout = (Component.getLayout || ((page) => (
-        <div className="flex min-h-screen">
-            <div className="">
+    const router = useRouter();
+
+    const noLayoutRoutes = ["/login", "/signup", "/findPassword"];
+    const isNoLayout = noLayoutRoutes.includes(router.pathname);
+
+    const getDefaultLayout = (page) => (
+        <div className="flex min-h-screen bg-gradient-to-b from-[#4A96EC] via-[#4A96EC] to-[#237BE6]">
+            <div>
                 <SideBarLayout />
             </div>
-            <div className="flex-grow flex flex-col">
-                <div className="">
+            <div className="flex-grow flex flex-col bg-[#FAFAFA] rounded-2xl my-5 mr-4">
+                <div>
                     <HeaderLayout />
                 </div>
-                <div className="flex-grow overflow-auto">
+                <div className="flex-grow overflow-auto px-3">
                     {page}
                 </div>
             </div>
         </div>
-    )));
+    );
+
+    const getLayout =
+        Component.getLayout ||
+        ((page) => (isNoLayout ? page : getDefaultLayout(page)));
 
     return (
         <Provider store={store}>
             <QueryClientProvider client={queryClient}>
-                <div className="flex min-h-screen bg-gradient-to-b from-[#4A96EC] via-[#4A96EC] to-[#237BE6]">
-                    <div className="">
-                        <SideBarLayout />
-                    </div>
-                    <div className="flex-grow flex flex-col bg-[#FAFAFA] rounded-2xl my-5 mr-4">
-                        <div className="">
-                            <HeaderLayout />
-                        </div>
-                        <div className="flex-grow overflow-auto px-3">
-                            <Component {...pageProps} />
-                        </div>
-                    </div>
-                </div>
+                {getLayout(<Component {...pageProps} />)}
             </QueryClientProvider>
         </Provider>
     );

--- a/src/components/units/findPassword/FindPassword.presenter.jsx
+++ b/src/components/units/findPassword/FindPassword.presenter.jsx
@@ -23,7 +23,7 @@ export default function FindPasswordUI({
             >
 
            
-        <div className="flex w-full h-screen justify-center items-center bg-[#F7F7F7]">
+        <div className="flex w-full h-screen min-h-[900px] justify-center items-center bg-[#F7F7F7]">
             <form className="flex flex-col items-center justify-center border rounded-2xl shadow-xl bg-[#FFFFFF] h-5/6 py-40 px-32 gap-12 w-2/5 min-w-[600px]" onSubmit={handleSubmit}>
                 <div className="flex flex-col gap-12 w-full">
                     <div className="flex flex-col items-center">

--- a/src/components/units/login/Login.presenter.jsx
+++ b/src/components/units/login/Login.presenter.jsx
@@ -23,8 +23,8 @@ export default function LoginUI({
             >
 
             
-        <div className="flex w-full h-screen justify-center items-center bg-[#F7F7F7]">
-            <form className="flex flex-col items-center justify-center border rounded-2xl shadow-xl bg-[#FFFFFF] h-5/6  px-32 py-40 px-32 gap-12 w-2/5 min-w-[600px]" onSubmit={handleSubmit}>
+        <div className="flex w-full h-screen min-h-[900px] justify-center items-center bg-[#F7F7F7]">
+            <form className="flex flex-col items-center justify-center border rounded-2xl shadow-xl bg-[#FFFFFF] h-5/6 px-32 py-40 px-32 gap-12 w-2/5 min-w-[600px]" onSubmit={handleSubmit}>
                 <div className="flex flex-col gap-12 w-full">
                     <div className="flex flex-col items-center">
                         <label className="text-3xl font-[700] text-[#247CE6]">동국대학교</label>

--- a/src/components/units/signup/SignUp.presenter.jsx
+++ b/src/components/units/signup/SignUp.presenter.jsx
@@ -46,7 +46,7 @@ export default function SignUpUI({
             }}
             >
                     
-        <div className="flex w-full h-screen justify-center items-center bg-[#F7F7F7]">
+        <div className="flex w-full h-screen min-h-[900px] justify-center items-center bg-[#F7F7F7]">
             <div className="flex flex-col items-center justify-center border rounded-2xl shadow-xl bg-[#FFFFFF] h-5/6 py-14 px-32 w-2/5 min-w-[600px]">
             {isContractOpen ? 
             


### PR DESCRIPTION
## 🔎 관련 이슈
closed #92 

## 🔎 작업 내용
화면을 세로로 찌그러트려도 내부 요소가 망가지지 않도록 min-height 속성 추가

<img width="1453" alt="스크린샷 2025-05-10 16 37 31" src="https://github.com/user-attachments/assets/73a6a4fa-e640-4b4f-8565-efb70c317007" />


