### PR TITLE
fix & feat: Redux 기반 accessToken 저장 및 Axios 인증 헤더/토큰 갱신 로직 개선

### DIFF
--- a/redux/slices/userSlice.js
+++ b/redux/slices/userSlice.js
@@ -1,18 +1,52 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
 
-const initialState = {
-    userName: '관리자', // 초기값 설정
-};
+export const fetchUserAndClubs = createAsyncThunk(
+  'user/fetchUserAndClubs',
+  async (_, { rejectWithValue }) => {
+    try {
+      const userRes = await axios.get("/user/me", { withCredentials: true });
+      const clubsRes = await axios.get("/user/me/club", { withCredentials: true });
+      return {
+        user: userRes.data,
+        clubs: clubsRes.data.content,
+      };
+    } catch (err) {
+      return rejectWithValue(err.response?.data || 'Error fetching data');
+    }
+  }
+);
 
 const userSlice = createSlice({
-    name: 'user',
-    initialState,
-    reducers: {
-        setUserName: (state, action) => {
-            state.userName = action.payload; // 사용자 이름 업데이트
-        },
+  name: 'user',
+  initialState: {
+    user: null,
+    clubs: [],
+    loading: false,
+    error: null,
+  },
+  reducers: {
+    setEmail(state, action) {
+      if (state.user) state.user.email = action.payload;
     },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchUserAndClubs.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchUserAndClubs.fulfilled, (state, action) => {
+        state.loading = false;
+        state.user = action.payload.user;
+        state.clubs = action.payload.clubs;
+      })
+      .addCase(fetchUserAndClubs.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload;
+      });
+  },
 });
 
-export const { setUserName } = userSlice.actions;
+export const { setEmail } = userSlice.actions;
 export default userSlice.reducer;

--- a/redux/store.js
+++ b/redux/store.js
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import userReducer from './slices/userSlice';
 import memberReducer from './slices/memberSlice';
+import authReducer from './slices/authSlice';
 
 const store = configureStore({
     reducer: {
         user: userReducer, // user 슬라이스 등록
         members: memberReducer,
+        auth: authReducer, // auth 슬라이스 등록
     },
 });
 

--- a/src/components/common/api.js
+++ b/src/components/common/api.js
@@ -1,0 +1,55 @@
+import axios from "axios";
+import store from "@/redux/store";
+import { setAccessToken, clearAccessToken } from "@/redux/slices/authSlice";
+
+const api = axios.create({
+    baseURL: "http://localhost:8081",
+    withCredentials: true,
+});
+
+// 요청 시 accessToken을 Redux에서 꺼내서 Authorization 헤더에 자동 설정
+api.interceptors.request.use(
+    (config) => {
+        const state = store.getState();
+        const token = state.auth.accessToken;
+        if (token) {
+            config.headers["Authorization"] = `Bearer ${token}`;
+        }
+        return config;
+    },
+    (error) => Promise.reject(error)
+);
+
+// 응답 오류 시 자동으로 refreshToken으로 accessToken 갱신 시도
+api.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+        const originalRequest = error.config;
+
+        if (error.response?.status === 401 && !originalRequest._retry) {
+            originalRequest._retry = true;
+            try {
+                const res = await api.post("/auth/refreshToken");
+                const newAccessToken = res.data.accessToken;
+
+                // Redux에 새 accessToken 저장
+                store.dispatch(setAccessToken(newAccessToken));
+
+                // Axios 기본 헤더 및 재요청 헤더에 토큰 설정
+                api.defaults.headers.common["Authorization"] = `Bearer ${newAccessToken}`;
+                originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
+
+                return api(originalRequest);
+            } catch (refreshError) {
+                console.error("리프레시 토큰 갱신 실패:", refreshError);
+                store.dispatch(clearAccessToken());
+                window.location.href = "/signIn"; // 자동 로그아웃 처리
+                return Promise.reject(refreshError);
+            }
+        }
+
+        return Promise.reject(error);
+    }
+);
+
+export default api;


### PR DESCRIPTION
## 🔎 관련 이슈
closed #97

## 🔎 작업 내용
	Redux에 accessToken 저장 기능 추가 (authSlice)
	Axios 요청 시 accessToken을 Authorization 헤더에 자동 첨부
	401 응답 발생 시 refreshToken을 사용해 accessToken 갱신
	갱신된 accessToken을 다시 Redux에 저장하고 요청 재시도
	갱신 실패 시 accessToken 제거 후 로그인 페이지로 이동


## 🔎 참고사항



